### PR TITLE
レポートリストデータを取得するアプリケーションサービスをレビュー用に評価ページで確認できるようにした

### DIFF
--- a/src/presentation/pages/Evaluation.tsx
+++ b/src/presentation/pages/Evaluation.tsx
@@ -1,10 +1,52 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { ReportListGetCommand } from "src/application/reportLists/reportListGetCommand";
+import { ReportListGetResult } from "src/application/reportLists/reportListGetResult";
+
 // ページ名称については検討の余地あり
 const Evaluation = () => {
+    const { reportId } = useParams<{ reportId: string }>();
 
+    // レビュー用にインポートができていることを確認するための表示するための変数
+    const [reportListGetResult, setReportListGetResult] = useState<ReportListGetResult | null>(null);
+
+    // TODO:
+    // レビュー用にインポートができていることを確認するための表示するために、レポートリストを取得する
+    // データ取得用のライブラリをいれて改修する必要あり
+    useEffect(() => {
+        const fetchReportList = async (reportId : string) => {
+            try {
+                const reportListData = await window.electronAPI.getReportListAsync(
+                    new ReportListGetCommand(Number(reportId))
+                );
+                setReportListGetResult(reportListData);
+            } catch (error) {
+                console.error("Failed to fetch report list:", error);
+            }
+        };
+
+        fetchReportList(reportId);
+    }, []);
+
+    
     return (
         <>
             <h1>Evaluation Page</h1>
             <p>評価対象のフォルダがインポートされたら、遷移されてくるページ</p>
+            {/* レビュー用にインポートができていることを確認するための表示 */}
+            {
+                reportListGetResult && (
+                    <div>
+                        <h2>{reportListGetResult.reportListData.reportId}:{reportListGetResult.reportListData.reportTitle}</h2>
+                        <p>{reportListGetResult.reportListData.courseId}:{reportListGetResult.reportListData.courseName}</p>
+                        <br />
+                        <p>学生</p>
+                        {reportListGetResult.reportListData.items.map((item) => (
+                            <div key={item.student.numId}>{item.student.name}: {item.submission.folderRelativePath}</div>
+                        ))}
+                    </div>
+                )
+            }
         </>
     );
 };


### PR DESCRIPTION
#105 で作成されたレポートリストデータを取得するアプリケーションサービスのインクリメントが、manakanを操作して確認できるように評価ページを変更している。

今後、このデータの取得方法はデータ取得用ライブラリを検討して、改修するつもりだが、7/9のレビュー用に表示するようにさせた。
![スクリーンショット 2024-07-09 003738](https://github.com/ChubachiPT2024/manakan/assets/64852663/3ee0b646-0242-4434-a25a-25773808435d)

これにて、インポート機能のPBIは終了でもよいのかなと考えています

