### PR TITLE
#123 レポートリストファイルのインポート時、ファイルがあるフォルダの絶対パスを保存するようにする

### DIFF
--- a/src/application/reportLists/reportListApplicationService.test.ts
+++ b/src/application/reportLists/reportListApplicationService.test.ts
@@ -62,6 +62,9 @@ describe('import', () => {
     expect(report.courseId).toBe(27048)
     expect(report.id).toBe(35677)
     expect(report.title).toBe('個人レポート課題')
+    expect(report.reportListFolderAbsoultePath).toBe(
+      path.join(__dirname, 'reportListImportTestFiles')
+    )
   })
 
   test('The first student is saved.', async () => {
@@ -188,7 +191,12 @@ describe('get', () => {
     )
     const course = new Course(27048, 'コミュニケーション技術特論2')
     await courseRepository.saveAsync(course)
-    const report = new Report(course.id, 35677, '個人レポート課題')
+    const report = new Report(
+      course.id,
+      35677,
+      '個人レポート課題',
+      'folderAbsolutePath'
+    )
     await reportRepository.saveAsync(report)
     const student = new Student('a2348mt', 23745148, '田中　真')
     await studentRepository.saveAsync(student)

--- a/src/application/reportLists/reportListApplicationService.ts
+++ b/src/application/reportLists/reportListApplicationService.ts
@@ -17,6 +17,7 @@ import { ReportListItemSubmissionData } from './reportListItemSubmissionData'
 import { ReportListItemAssessmentData } from './reportListItemAssessmentData'
 import { ReportListItemStudentData } from './reportListItemStudentData'
 import { ReportListData } from './reportListData'
+import path from 'path'
 
 /**
  * レポートリストアプリケーションサービス
@@ -49,7 +50,9 @@ export class ReportListApplicationService {
     reportListImportCommand: ReportListImportCommand
   ): Promise<number> {
     const workbook = new Excel.Workbook()
-    await workbook.xlsx.readFile(reportListImportCommand.reportListFilePath)
+    await workbook.xlsx.readFile(
+      reportListImportCommand.reportListFileAbsolutePath
+    )
 
     // id によるアクセスは非推奨らしいので、名前でアクセス
     // https://github.com/exceljs/exceljs?tab=readme-ov-file#access-worksheets
@@ -64,8 +67,11 @@ export class ReportListApplicationService {
 
     const reportId = Number(worksheet.getCell('B3').text)
     const reportTitle = worksheet.getCell('C3').text
+    const reportListFolderAbsolutePath = path.dirname(
+      reportListImportCommand.reportListFileAbsolutePath
+    )
     await this.reportRepository.saveAsync(
-      new Report(courseId, reportId, reportTitle)
+      new Report(courseId, reportId, reportTitle, reportListFolderAbsolutePath)
     )
 
     for (let i = 8; ; i++) {

--- a/src/application/reportLists/reportListImportCommand.ts
+++ b/src/application/reportLists/reportListImportCommand.ts
@@ -5,7 +5,7 @@ export class ReportListImportCommand {
   /**
    * コンストラクタ
    *
-   * @param reportListFilePath レポートリストファイルパス
+   * @param reportListFileAbsolutePath レポートリストファイルの絶対パス
    */
-  public constructor(public readonly reportListFilePath: string) {}
+  public constructor(public readonly reportListFileAbsolutePath: string) {}
 }

--- a/src/domain/models/reports/report.ts
+++ b/src/domain/models/reports/report.ts
@@ -8,10 +8,12 @@ export class Report {
    * @param courseId コース ID
    * @param id ID
    * @param title タイトル
+   * @param reportListFolderAbsoultePath レポートリストフォルダの絶対パス
    */
   public constructor(
     public readonly courseId: number,
     public readonly id: number,
-    public readonly title: string
+    public readonly title: string,
+    public readonly reportListFolderAbsoultePath: string
   ) {}
 }


### PR DESCRIPTION
提出物ファイルを参照する際に必要になると思われるので、レポートリストファイルのインポート時に、ファイルがあるフォルダの絶対パスを保存するようにしました。