### PR TITLE
typo 修正

### DIFF
--- a/src/@types/interface.d.ts
+++ b/src/@types/interface.d.ts
@@ -41,7 +41,7 @@ export interface IElectronAPI {
   ) => Promise<SubmissionSummariesGetResult>
 
   getSubmissionFileAsync: (
-    comman: SubmissionFileGetCommand
+    command: SubmissionFileGetCommand
   ) => Promise<SubmissionFileGetResult>
 }
 


### PR DESCRIPTION
`comman` を `command` に修正しました。