### PR TITLE
typescript.tsserver.experimental.enableProjectDiagnostics を有効化する

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,6 @@
     "typescript",
     "typescriptreact"
   ],
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "typescript.tsserver.experimental.enableProjectDiagnostics": true
 }


### PR DESCRIPTION
エラーの見落としがあったので、解決方法を探したところ、このオプションを有効化すると、開いていないファイルのエラーも表示されるようになるようです。
https://stackoverflow.com/questions/55201424/how-to-get-vscode-to-show-typescript-errors-for-files-not-open-in-the-editor

追加して問題なさそうであれば Approve をお願いします。