### PR TITLE
Reviewページでのデータ取得

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-drag-drop-files": "^2.3.10",
         "react-icons": "^5.2.1",
         "react-pdf": "^9.1.0",
-        "react-router-dom": "^6.23.1"
+        "react-router-dom": "^6.23.1",
+        "swr": "^2.2.5"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.4.0",
@@ -4672,6 +4673,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -12300,6 +12306,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12997,6 +13015,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/username": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-drag-drop-files": "^2.3.10",
     "react-icons": "^5.2.1",
     "react-pdf": "^9.1.0",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "swr": "^2.2.5"
   }
 }

--- a/src/presentation/common/button/BackButton.tsx
+++ b/src/presentation/common/button/BackButton.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom'
+import { MdKeyboardDoubleArrowLeft } from 'react-icons/md'
+
+interface IPropsButton {
+  href: string
+}
+
+// 戻るボタンを抽象化したコンポーネント
+export const BackButton: React.FC<IPropsButton> = ({ href }) => {
+  const navigate = useNavigate()
+
+  // 戻るボタンが押された時の処理
+  const handleBack = (href: string) => {
+    navigate(href)
+  }
+
+  return (
+    <>
+      <MdKeyboardDoubleArrowLeft
+        className="w-12 h-12 cursor-pointer transition duration-200 ease-in-out hover:scale-150"
+        color={'#a9a9a9'}
+        onClick={() => handleBack(href)}
+      />
+    </>
+  )
+}

--- a/src/presentation/common/error/Error.tsx
+++ b/src/presentation/common/error/Error.tsx
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom'
+
+const Error = () => {
+  const navigate = useNavigate()
+  return (
+    <>
+      <div
+        className="flex justify-center items-center h-screen"
+        aria-label="読み込み中"
+      >
+        <div className="text-center">
+          <h1 className="text-2xl mb-5">エラーが発生しました</h1>
+          <button
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            onClick={() => navigate('/')}
+          >
+            ホームへ戻る
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default Error

--- a/src/presentation/common/isLoading/Loading.tsx
+++ b/src/presentation/common/isLoading/Loading.tsx
@@ -1,0 +1,12 @@
+const Loading = () => {
+  return (
+    <div
+      className="flex justify-center items-center h-screen"
+      aria-label="読み込み中"
+    >
+      <div className="animate-spin h-10 w-10 border-4 border-blue-500 rounded-full border-t-transparent"></div>
+    </div>
+  )
+}
+
+export default Loading

--- a/src/presentation/pages/Classification.tsx
+++ b/src/presentation/pages/Classification.tsx
@@ -18,6 +18,8 @@ import { ReportListGetCommand } from 'src/application/reportLists/reportListGetC
 import { Report } from '../types/report'
 import { AssessmentRank } from '../types/submission'
 import { AssessmentClassifyCommand } from 'src/application/assessments/assessmentClassifyCommand'
+import Loading from '../common/isLoading/Loading'
+import Error from '../common/error/Error'
 
 const Classification = () => {
   const { id } = useParams()
@@ -199,37 +201,11 @@ const Classification = () => {
   )
 
   if (process === 'loading') {
-    return (
-      <>
-        <div
-          className="flex justify-center items-center h-screen"
-          aria-label="読み込み中"
-        >
-          <div className="animate-spin h-10 w-10 border-4 border-blue-500 rounded-full border-t-transparent"></div>
-        </div>
-      </>
-    )
+    return <Loading />
   }
 
   if (process === 'error') {
-    return (
-      <>
-        <div
-          className="flex justify-center items-center h-screen"
-          aria-label="読み込み中"
-        >
-          <div className="text-center">
-            <h1 className="text-2xl mb-5">エラーが発生しました</h1>
-            <button
-              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-              onClick={() => navigate('/')}
-            >
-              ホームへ戻る
-            </button>
-          </div>
-        </div>
-      </>
-    )
+    return <Error />
   }
 
   const draggingItem = report.items.find(

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -13,45 +13,15 @@ import { SubmissionSummariesGetCommand } from 'src/application/submissionSummari
 
 const Review = () => {
   const location = useLocation()
-  const { reportId, studentNumIds } = location.state
-  const [submissionSummaries, setSubmissionSummaries] = useState([])
 
-  useEffect(() => {
-    window.electronAPI
-      .getSubmissionSummariesAsync(
-        new SubmissionSummariesGetCommand(Number(reportId), studentNumIds)
-      )
-      .then((res) => {
-        setSubmissionSummaries(res.submissionSummaries)
-      })
-  }, [reportId, studentNumIds])
+  // 提出物サマリーを取得
+  const { submissionSummaries, error, isLoading } = useSubmissionSummaries(
+    reportId,
+    studentNumIds
+  )
 
-  // 評点の状態
-  const [grade, setGrade] = useState<number>(0)
-
-  // 評点が変更された時の処理
-  const handleChange = (event: SelectChangeEvent) => {
-    setGrade(Number(event.target.value))
-  }
-
-  // 学生名と対応するPDFファイルのパスを含むオブジェクトの配列
-  const students = [
-    {
-      name: '学生1',
-    },
-    {
-      name: '学生2',
-    },
-    {
-      name: '学生3',
-    },
-    {
-      name: '学生4',
-    },
-    {
-      name: '学生5',
-    },
-  ]
+  if (isLoading) return <Loading />
+  if (error) return <Error />
 
   return (
     <>

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -1,6 +1,6 @@
 // ReviewPage.tsx
 import { useEffect, useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import FormControlLabel from '@mui/material/FormControlLabel'
@@ -8,12 +8,10 @@ import FormControl from '@mui/material/FormControl'
 import MenuItem from '@mui/material/MenuItem'
 import Select, { SelectChangeEvent } from '@mui/material/Select'
 import TextField from '@mui/material/TextField'
-import { MdKeyboardDoubleArrowLeft } from 'react-icons/md'
 import PdfView from '../review/components/PdfView'
 import { SubmissionSummariesGetCommand } from 'src/application/submissionSummaries/submissionSummariesGetCommand'
 
 const Review = () => {
-  const navigate = useNavigate()
   const location = useLocation()
   const { reportId, studentNumIds } = location.state
   const [submissionSummaries, setSubmissionSummaries] = useState([])
@@ -27,10 +25,6 @@ const Review = () => {
         setSubmissionSummaries(res.submissionSummaries)
       })
   }, [reportId, studentNumIds])
-
-  const handleBack = () => {
-    navigate(`/classification/${location.state.reportId}`)
-  }
 
   // 評点の状態
   const [grade, setGrade] = useState<number>(0)
@@ -65,11 +59,7 @@ const Review = () => {
         {/* navbar */}
         <div className="z-50 bg-white fixed top-0 flex items-center w-full p-2 border-b shadow-sm">
           {/* 戻るボタン */}
-          <MdKeyboardDoubleArrowLeft
-            className="w-12 h-12 cursor-pointer transition duration-200 ease-in-out  hover:scale-110"
-            color={'#a9a9a9'}
-            onClick={handleBack}
-          />
+          <BackButton href={`/classification/${reportId}`} />
         </div>
 
         {/* メインコンテンツ */}

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -1,8 +1,6 @@
 // ReviewPage.tsx
 import { useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
-import 'react-pdf/dist/esm/Page/TextLayer.css'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import FormControlLabel from '@mui/material/FormControlLabel'

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -1,18 +1,21 @@
-// ReviewPage.tsx
-import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
-import Radio from '@mui/material/Radio'
-import RadioGroup from '@mui/material/RadioGroup'
-import FormControlLabel from '@mui/material/FormControlLabel'
-import FormControl from '@mui/material/FormControl'
-import MenuItem from '@mui/material/MenuItem'
-import Select, { SelectChangeEvent } from '@mui/material/Select'
-import TextField from '@mui/material/TextField'
 import PdfView from '../review/components/PdfView'
-import { SubmissionSummariesGetCommand } from 'src/application/submissionSummaries/submissionSummariesGetCommand'
+import Sidebar from '../review/components/Sidebar'
+import { useSubmissionSummaries } from '../review/hooks/useSubmissionSummaries'
+import { BackButton } from '../common/button/BackButton'
+import Loading from '../common/isLoading/Loading'
+import Error from '../common/error/Error'
+
+// ルーティング時に渡される情報の型
+type LocationState = {
+  reportId: string
+  studentNumIds: number[]
+}
 
 const Review = () => {
+  // ルーティング時に渡された情報を取得
   const location = useLocation()
+  const { reportId, studentNumIds } = location.state as LocationState
 
   // 提出物サマリーを取得
   const { submissionSummaries, error, isLoading } = useSubmissionSummaries(
@@ -49,110 +52,10 @@ const Review = () => {
             ))}
           </div>
 
-          {/* sidebar */}
-          <div className="w-96 p-4 m-2 border-l-4 flex flex-col justify-start overflow-y-auto">
-            {/* 学生選択のラジオボタン */}
-            <div className="flex flex-col m-1">
-              <FormControl>
-                <h2 className="text-xl font-bold mb-1">学生選択</h2>
-                <RadioGroup
-                  aria-labelledby="radio-buttons-group-label"
-                  defaultValue="学生1"
-                  name="radio-buttons-group"
-                >
-                  {students.map((student, index) => (
-                    <FormControlLabel
-                      key={index}
-                      value={student.name}
-                      control={<Radio />}
-                      label={student.name}
-                      sx={{ m: '0' }}
-                    />
-                  ))}
-                </RadioGroup>
-              </FormControl>
-            </div>
-
-            {/* 提出者情報 */}
-            <div className="flex flex-col m-1">
-              <h2 className="text-xl font-bold mb-2">提出者情報</h2>
-              <ul className="pl-3">
-                <li className="mb-2">学生名：学生1</li>
-                <li className="mb-2">学籍番号：0000000</li>
-                <li className="mb-2">提出日時：2021/09/01 12:00</li>
-              </ul>
-            </div>
-
-            {/* 分類 セレクトボタン*/}
-            <div className="m-1">
-              <h2 className="text-xl font-bold mb-2">分類</h2>
-              <div className="pl-3">
-                <FormControl fullWidth>
-                  <Select
-                    id="select"
-                    inputProps={{ 'aria-label': 'Without label' }}
-                    value={grade.toString()}
-                    onChange={handleChange}
-                  >
-                    <MenuItem value={5}>5</MenuItem>
-                    <MenuItem value={4}>4</MenuItem>
-                    <MenuItem value={3}>3</MenuItem>
-                    <MenuItem value={2}>2</MenuItem>
-                    <MenuItem value={1}>1</MenuItem>
-                    <MenuItem value={0}>0</MenuItem>
-                  </Select>
-                </FormControl>
-              </div>
-            </div>
-
-            {/* 点数 */}
-            <div className="m-1">
-              <h2 className="text-xl font-bold mb-2">点数</h2>
-              <div className="pl-3">
-                <TextField
-                  id="score"
-                  type="number"
-                  value={100}
-                  variant="outlined"
-                  fullWidth
-                  inputProps={{
-                    'aria-label': 'Without label',
-                    min: 0,
-                    max: 100,
-                  }}
-                />
-              </div>
-            </div>
-
-            {/* メモ テキストエリア*/}
-            <div className="m-1">
-              <h2 className="text-xl font-bold mb-2">メモ</h2>
-              <div className="pl-3">
-                <TextField
-                  id="memo"
-                  multiline
-                  rows={4}
-                  placeholder="評価の為の一時的なメモを記述して下さい。このデータはmanabaには反映されません。"
-                  sx={{ m: '0' }}
-                  fullWidth
-                />
-              </div>
-            </div>
-
-            {/* フィードバック テキストエリア*/}
-            <div className="m-1">
-              <h2 className="text-xl font-bold mb-2">フィードバック</h2>
-              <div className="pl-3">
-                <TextField
-                  id="feedback"
-                  multiline
-                  rows={4}
-                  placeholder="学生に伝える為のフィードバックを記述して下さい。"
-                  fullWidth
-                />
-              </div>
-            </div>
-          </div>
+          <Sidebar
+            reportId={reportId}
+            submissionSummaries={submissionSummaries}
+          />
         </div>
       </div>
     </>

--- a/src/presentation/review/components/FeedbackTextarea.tsx
+++ b/src/presentation/review/components/FeedbackTextarea.tsx
@@ -1,0 +1,43 @@
+import TextField from '@mui/material/TextField'
+import { SubmissionSummaryData } from 'src/application/submissionSummaries/submissionSummaryData'
+import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
+
+// フィードバック入力欄のProps
+interface FeedbackTextareaProps {
+  reportId: string
+  submissionSummaries: SubmissionSummaryData[]
+  selectedStudent: SubmissionSummaryStudentData
+}
+
+// フィードバック入力欄コンポーネント
+const FeedbackTextarea: React.FC<FeedbackTextareaProps> = ({
+  reportId,
+  submissionSummaries,
+  selectedStudent,
+}) => {
+  // フィードバックの値
+  const feedbackValue =
+    submissionSummaries.find(
+      (summary: SubmissionSummaryData) =>
+        summary.student.numId === selectedStudent.numId
+    )?.assessment.feedback || ''
+
+  return (
+    <div className="m-1">
+      <h2 className="text-xl font-bold mb-2">フィードバック</h2>
+      <div className="pl-3">
+        <TextField
+          id="feedback"
+          multiline
+          rows={6}
+          placeholder="学生に伝える為のフィードバックを記述して下さい。"
+          value={feedbackValue}
+          sx={{ m: '0' }}
+          fullWidth
+        />
+      </div>
+    </div>
+  )
+}
+
+export default FeedbackTextarea

--- a/src/presentation/review/components/GradeSelect.tsx
+++ b/src/presentation/review/components/GradeSelect.tsx
@@ -1,0 +1,57 @@
+import FormControl from '@mui/material/FormControl'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import { SubmissionSummaryData } from 'src/application/submissionSummaries/submissionSummaryData'
+import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
+import { AssessmentGrade } from 'src/domain/models/assessments/assessmentGrade'
+
+// 評点選択コンポーネントのProps
+interface GradeSelectProps {
+  reportId: string
+  submissionSummaries: SubmissionSummaryData[]
+  selectedStudent: SubmissionSummaryStudentData
+}
+
+// 評点選択コンポーネント
+const GradeSelect: React.FC<GradeSelectProps> = ({
+  reportId,
+  submissionSummaries,
+  selectedStudent,
+}) => {
+  // 評点の選択肢
+  const menuItems = Array.from({ length: 6 }, (_, index) => (
+    <MenuItem key={index} value={(5 - index) as AssessmentGrade}>
+      {5 - index}
+    </MenuItem>
+  ))
+
+  // 選択された学生の評点
+  const selectedGrade =
+    submissionSummaries.find(
+      (summary: SubmissionSummaryData) =>
+        summary.student.numId === selectedStudent.numId
+    )?.assessment.grade || ''
+
+  return (
+    <div className="m-1">
+      <h2 className="text-xl font-bold mb-2">分類</h2>
+      <div className="pl-3">
+        <FormControl fullWidth>
+          <Select
+            id="select"
+            inputProps={{ 'aria-label': 'Without label' }}
+            value={selectedGrade}
+            displayEmpty
+          >
+            <MenuItem value="" disabled>
+              評点を選択して下さい
+            </MenuItem>
+            {menuItems}
+          </Select>
+        </FormControl>
+      </div>
+    </div>
+  )
+}
+
+export default GradeSelect

--- a/src/presentation/review/components/MemoTextarea.tsx
+++ b/src/presentation/review/components/MemoTextarea.tsx
@@ -1,0 +1,43 @@
+import TextField from '@mui/material/TextField'
+import { SubmissionSummaryData } from 'src/application/submissionSummaries/submissionSummaryData'
+import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
+
+// メモ入力欄のProps
+interface MemoTextareaProps {
+  reportId: string
+  submissionSummaries: SubmissionSummaryData[]
+  selectedStudent: SubmissionSummaryStudentData
+}
+
+// メモ入力欄コンポーネント
+const MemoTextarea: React.FC<MemoTextareaProps> = ({
+  reportId,
+  submissionSummaries,
+  selectedStudent,
+}) => {
+  // メモの値
+  const memoValue =
+    submissionSummaries.find(
+      (summary: SubmissionSummaryData) =>
+        summary.student.numId === selectedStudent.numId
+    )?.assessment.memo || ''
+
+  return (
+    <div className="m-1">
+      <h2 className="text-xl font-bold mb-2">メモ</h2>
+      <div className="pl-3">
+        <TextField
+          id="memo"
+          multiline
+          rows={6}
+          placeholder="評価の為の一時的なメモを記述して下さい。このデータはmanabaには反映されません。"
+          value={memoValue}
+          sx={{ m: '0' }}
+          fullWidth
+        />
+      </div>
+    </div>
+  )
+}
+
+export default MemoTextarea

--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -4,8 +4,8 @@ import { SubmissionSummaryData } from 'src/application/submissionSummaries/submi
 import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
 import StudentSelectionRadioGroup from 'src/presentation/review/components/StudentSelectionRadioGroup'
 import GradeSelect from 'src/presentation/review/components/GradeSelect'
-import MemoTextarea from './MemoTextarea'
-import FeedbackTextarea from './FeedbackTextarea'
+import MemoTextarea from 'src/presentation/review/components/MemoTextarea'
+import FeedbackTextarea from 'src/presentation/review/components/FeedbackTextarea'
 
 // サイドバーのProps
 interface IPropsSidebar {

--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import TextField from '@mui/material/TextField'
+import { SubmissionSummaryData } from 'src/application/submissionSummaries/submissionSummaryData'
+import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
+import StudentSelectionRadioGroup from 'src/presentation/review/components/StudentSelectionRadioGroup'
+import GradeSelect from 'src/presentation/review/components/GradeSelect'
+import MemoTextarea from './MemoTextarea'
+import FeedbackTextarea from './FeedbackTextarea'
+
+// サイドバーのProps
+interface IPropsSidebar {
+  reportId: string
+  submissionSummaries: SubmissionSummaryData[]
+}
+
+// reviewページサイドバーコンポーネント
+const Sidebar: React.FC<IPropsSidebar> = ({
+  reportId,
+  submissionSummaries,
+}) => {
+  // 選択された学生
+  const [selectedStudent, setSelectedStudent] =
+    useState<SubmissionSummaryStudentData>(submissionSummaries[0].student)
+
+  return (
+    <div className="w-96 p-4 m-2 border-l-4 flex flex-col justify-start overflow-y-auto">
+      <StudentSelectionRadioGroup
+        submissionSummaries={submissionSummaries}
+        selectedStudent={selectedStudent}
+        setSelectedStudent={setSelectedStudent}
+      />
+
+      {/* 提出者情報 */}
+      <div className="flex flex-col m-1">
+        <h2 className="text-xl font-bold mb-2">提出者情報</h2>
+        <ul className="pl-3">
+          <li className="mb-2">学生名：{selectedStudent.name}</li>
+          <li className="mb-2">学籍番号：{selectedStudent.numId}</li>
+          {/* TODO 提出者情報の取得 */}
+          <li className="mb-2">提出日時：2021/09/01 12:00</li>
+        </ul>
+      </div>
+
+      {/* 評点 セレクトボタン*/}
+      <GradeSelect
+        reportId={reportId}
+        submissionSummaries={submissionSummaries}
+        selectedStudent={selectedStudent}
+      />
+
+      {/* TODO: rankをどう表現するか べつにセレクトボックスをもたせるかどうか　*/}
+
+      {/* 点数 */}
+      <div className="m-1">
+        <h2 className="text-xl font-bold mb-2">点数</h2>
+        <div className="pl-3">
+          <TextField
+            id="score"
+            type="number"
+            disabled
+            value={
+              submissionSummaries.find(
+                (summary: SubmissionSummaryData) =>
+                  summary.student.numId === selectedStudent.numId
+              )?.assessment.score
+            }
+            variant="outlined"
+            fullWidth
+            inputProps={{
+              'aria-label': 'Without label',
+              min: 0,
+              max: 100,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* メモ */}
+      <MemoTextarea
+        reportId={reportId}
+        submissionSummaries={submissionSummaries}
+        selectedStudent={selectedStudent}
+      />
+
+      {/* フィードバック */}
+      <FeedbackTextarea
+        reportId={reportId}
+        submissionSummaries={submissionSummaries}
+        selectedStudent={selectedStudent}
+      />
+    </div>
+  )
+}
+
+export default Sidebar

--- a/src/presentation/review/components/StudentSelectionRadioGroup.tsx
+++ b/src/presentation/review/components/StudentSelectionRadioGroup.tsx
@@ -1,0 +1,59 @@
+import Radio from '@mui/material/Radio'
+import RadioGroup from '@mui/material/RadioGroup'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormControl from '@mui/material/FormControl'
+import { SubmissionSummaryData } from 'src/application/submissionSummaries/submissionSummaryData'
+import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
+
+// 学生選択ラジオボタンのProps
+interface IPropsStudentSelectionRadioGroup {
+  submissionSummaries: SubmissionSummaryData[]
+  selectedStudent: SubmissionSummaryStudentData
+  setSelectedStudent: React.Dispatch<
+    React.SetStateAction<SubmissionSummaryStudentData>
+  >
+}
+
+// 学生選択ラジオボタン
+const StudenSelectionRadioGroup: React.FC<IPropsStudentSelectionRadioGroup> = ({
+  submissionSummaries,
+  selectedStudent,
+  setSelectedStudent,
+}) => {
+  // 学生選択ラジオボタンでの選択時の処理
+  const handleStudentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = submissionSummaries.find(
+      (summary: SubmissionSummaryData) =>
+        summary.student.numId === Number(event.target.value)
+    )
+    if (selected) {
+      setSelectedStudent(selected.student)
+    }
+  }
+
+  return (
+    <div className="flex flex-col m-1">
+      <FormControl>
+        <h2 className="text-xl font-bold mb-1">学生選択</h2>
+        <RadioGroup
+          aria-labelledby="radio-buttons-group-label"
+          value={selectedStudent.numId}
+          name="radio-buttons-group"
+          onChange={handleStudentChange}
+        >
+          {submissionSummaries.map((summary: SubmissionSummaryData) => (
+            <FormControlLabel
+              key={summary.student.numId}
+              value={summary.student.numId}
+              control={<Radio />}
+              label={summary.student.name}
+              sx={{ m: '0' }}
+            />
+          ))}
+        </RadioGroup>
+      </FormControl>
+    </div>
+  )
+}
+
+export default StudenSelectionRadioGroup

--- a/src/presentation/review/hooks/useSubmissionSummaries.tsx
+++ b/src/presentation/review/hooks/useSubmissionSummaries.tsx
@@ -1,0 +1,37 @@
+import { SubmissionSummariesGetCommand } from 'src/application/submissionSummaries/submissionSummariesGetCommand'
+import { SubmissionSummariesGetResult } from 'src/application/submissionSummaries/submissionSummariesGetResult'
+import useSWR from 'swr'
+
+/**
+ * 提出者サマリーを取得する
+ *
+ * @param reportId
+ * @param studentNumIds
+ * @returns
+ */
+async function getSubmissionSummaries(
+  reportId: string,
+  studentNumIds: number[]
+): Promise<SubmissionSummariesGetResult> {
+  return window.electronAPI.getSubmissionSummariesAsync(
+    new SubmissionSummariesGetCommand(Number(reportId), studentNumIds)
+  )
+}
+
+// useSWRを使ったカスタムフック
+export const useSubmissionSummaries = (
+  reportId: string,
+  studentNumIds: number[]
+) => {
+  const { data, error, isLoading } = useSWR<SubmissionSummariesGetResult>(
+    'SubmissionSummaries',
+    () => getSubmissionSummaries(reportId, studentNumIds)
+  )
+
+  return {
+    //　疑問点:reportIdも返す必要があるかどうか
+    submissionSummaries: data?.submissionSummaries,
+    error,
+    isLoading,
+  }
+}


### PR DESCRIPTION
# やったこと
- reviewページ部分でのデータの取得をuseEffectから、swr方式に変更した
- reviewページのサイドバーをコンポーネントとして、切り出して、各部品に分解した(書き込みを行う必要があるところだけ)
- 切り出したコンポーネントで、取得したデータを表示して、ラジオボタンで選択している学生の情報に切り替わるようにした
- 分類ページに戻るボタンがなかったので、reviewページ用に作ったものを抽象化した
- ローディング画面、エラー画面の共通化

# デモ
![ManakanUbuntu2024-07-1522-37-44-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/218fd468-86e2-40b8-ad4b-206a3044caa9)


# 相談
評点内でのrankをどう選択してもらうか
- セレクトコンポーネントをそれぞれで持つか
- 5++、5+、5+-、5-、5--、4++、4+、4+-、4-...と選択肢をもつか


### 参考
https://swr.vercel.app/ja
https://qiita.com/musenmai/items/e09c0b798a05522a33cf#hooks%E3%81%AB%E3%81%BE%E3%81%A8%E3%82%81%E3%82%8B
https://qiita.com/hakshu/items/3f2810bfff751b38c612
https://zenn.dev/yukikoma/articles/17adad7fedd5af#%E7%BD%AE%E3%81%8D%E6%8F%9B%E3%81%88%E3%81%AE%E4%BE%8B
https://zenn.dev/mast1ff/articles/5b48a87242f9f0#%E3%83%87%E3%83%BC%E3%82%BF%E3%81%AE%E6%9B%B4%E6%96%B0%E5%87%A6%E7%90%86

