### PR TITLE
Fix/not submitted on pdf view.tsx

### DIFF
--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -25,7 +25,6 @@ const Review = () => {
 
   if (isLoading) return <Loading />
   if (error) return <Error />
-  console.log('Review.tsx: submissionSummaries', submissionSummaries)
   return (
     <>
       <div className="h-full overflow-hidden">

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -25,7 +25,7 @@ const Review = () => {
 
   if (isLoading) return <Loading />
   if (error) return <Error />
-
+  console.log('Review.tsx: submissionSummaries', submissionSummaries)
   return (
     <>
       <div className="h-full overflow-hidden">
@@ -48,6 +48,7 @@ const Review = () => {
                 height="calc(100vh - 4rem)"
                 width={900}
                 pageHeight={1000}
+                submission={summary.submission}
               />
             ))}
           </div>

--- a/src/presentation/review/components/PdfView.tsx
+++ b/src/presentation/review/components/PdfView.tsx
@@ -3,7 +3,6 @@ import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
 import { SubmissionFileGetCommand } from 'src/application/submissionFiles/submissionFileGetCommand'
-// import { Submission } from 'src/domain/models/submissions/submission'
 // pdfjs-distからpdf.worker.min.jsファイルへのパスを設定
 pdfjs.GlobalWorkerOptions.workerSrc = `./pdf.worker.min.mjs`
 
@@ -39,7 +38,7 @@ const PdfView: React.FC<PdfViewProps> = ({
   pageHeight,
   submission,
 }) => {
-  console.log(submission)
+  // 未提出の場合は例外テキストを表示
   if (!submission.isSubmitted) {
     return (
       <div className="text-center" style={{ height, width }}>
@@ -101,7 +100,7 @@ const PdfView: React.FC<PdfViewProps> = ({
       <div className="overflow-y-auto" style={{ height }}>
         {memoizedFiles.map(({ file, index }) => (
           <div
-            key={index}
+            key={`${student.userId}-${index}`}
             className="mb-5 overflow-y-auto"
             style={{ width, height: pageHeight }}
           >

--- a/src/presentation/review/components/PdfView.tsx
+++ b/src/presentation/review/components/PdfView.tsx
@@ -3,7 +3,7 @@ import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
 import { SubmissionFileGetCommand } from 'src/application/submissionFiles/submissionFileGetCommand'
-
+// import { Submission } from 'src/domain/models/submissions/submission'
 // pdfjs-distからpdf.worker.min.jsファイルへのパスを設定
 pdfjs.GlobalWorkerOptions.workerSrc = `./pdf.worker.min.mjs`
 
@@ -20,6 +20,13 @@ interface PdfViewProps {
   height: string
   width: number
   pageHeight: number
+  submission: Submission
+}
+
+interface Submission {
+  isSubmitted: boolean
+  submissionDateTime?: string
+  submissionCount?: number
 }
 
 // 以下の Props を学籍番号を受けとる様に修正し、useEffect内で API 経由でPDFファイルを取得するように修正予定
@@ -30,7 +37,18 @@ const PdfView: React.FC<PdfViewProps> = ({
   height,
   width,
   pageHeight,
+  submission,
 }) => {
+  console.log(submission)
+  if (!submission.isSubmitted) {
+    return (
+      <div className="text-center" style={{ height, width }}>
+        <h2 className="text-2xl font-bold">{student.name}</h2>
+        <p>未提出の為、表示するデータがありません</p>
+      </div>
+    )
+  }
+
   const [pdfDatas, setPdfDatas] = useState<string[]>([])
   const [numPages, setNumPages] = useState<number[]>([])
 

--- a/src/presentation/review/components/PdfView.tsx
+++ b/src/presentation/review/components/PdfView.tsx
@@ -43,7 +43,9 @@ const PdfView: React.FC<PdfViewProps> = ({
     return (
       <div className="text-center p-4 border-x" style={{ height, width }}>
         <h2 className="text-2xl font-bold">{student.name}</h2>
-        <p>未提出の為、表示するデータがありません</p>
+        <p className="border border-gray-300 p-4 rounded bg-gray-100">
+          未提出の為、表示するデータがありません
+        </p>
       </div>
     )
   }

--- a/src/presentation/review/components/PdfView.tsx
+++ b/src/presentation/review/components/PdfView.tsx
@@ -41,7 +41,7 @@ const PdfView: React.FC<PdfViewProps> = ({
   // 未提出の場合は例外テキストを表示
   if (!submission.isSubmitted) {
     return (
-      <div className="text-center" style={{ height, width }}>
+      <div className="text-center p-4 border-x" style={{ height, width }}>
         <h2 className="text-2xl font-bold">{student.name}</h2>
         <p>未提出の為、表示するデータがありません</p>
       </div>
@@ -95,7 +95,7 @@ const PdfView: React.FC<PdfViewProps> = ({
   )
 
   return (
-    <div className="text-center" style={{ height, width }}>
+    <div className="text-center p-4 border-x" style={{ height, width }}>
       <h2 className="text-2xl font-bold">{student.name}</h2>
       <div className="overflow-y-auto" style={{ height }}>
         {memoizedFiles.map(({ file, index }) => (


### PR DESCRIPTION
- 概要
  - Review.tsx karal submission={summary.submission} を props で PdfView.tsx に渡し、isSubmitted: false の際に例外テキストを表示する様に変更。

![image](https://github.com/user-attachments/assets/430a7c60-585f-4cd7-9785-756befb7ba0c)

- その他の修正
  - テキストのみ表示した際に、学生毎の提出物表示ページで境目がない為、ボーダーとパディングを設定
  - PdfView の index={key} の部分をこっそり修正