### PR TITLE
インポートページでの再開する用のAPI

### DIFF
--- a/src/@types/interface.d.ts
+++ b/src/@types/interface.d.ts
@@ -21,6 +21,8 @@ export interface IElectronAPI {
     reportListExportCommand: ReportListExportCommand
   ) => Promise<ReportListExportResult>
 
+  getReportCourseAsync: () => Promise<ReportCourseGetResult[]>
+
   getReportListAsync: (
     reportListGetCommand: ReportListGetCommand
   ) => Promise<ReportListGetResult>

--- a/src/application/reportLists/reportCourseData.ts
+++ b/src/application/reportLists/reportCourseData.ts
@@ -1,0 +1,19 @@
+/**
+ * レポートとコースのデータ
+ */
+export class ReportCourseData {
+  /**
+   * コンストラクタ
+   *
+   * @param courseId コース ID
+   * @param courseName コース名
+   * @param reportId レポート ID
+   * @param reportTitle レポートタイトル
+   */
+  public constructor(
+    public readonly courseId: number,
+    public readonly courseName: string,
+    public readonly reportId: number,
+    public readonly reportTitle: string
+  ) {}
+}

--- a/src/application/reportLists/reportCourseGetResult.ts
+++ b/src/application/reportLists/reportCourseGetResult.ts
@@ -1,0 +1,13 @@
+import { ReportCourseData } from './reportCourseData'
+
+/**
+ * レポートとコース取得結果
+ */
+export class ReportCourseGetResult {
+  /**
+   * コンストラクタ
+   *
+   * @param reportListData レポートコースデータ
+   */
+  public constructor(public readonly reportListData: ReportCourseData) {}
+}

--- a/src/application/reportLists/reportListApplicationService.test.ts
+++ b/src/application/reportLists/reportListApplicationService.test.ts
@@ -266,6 +266,38 @@ describe('get', () => {
     expect(item.assessment.rank).toBeUndefined()
     expect(item.assessment.score).toBeUndefined()
   })
+
+  test('Can get report course', async () => {
+    const courseRepository = new InMemoryCourseRepository()
+    const reportRepository = new InMemoryReportRepository()
+    const studentRepository = new InMemoryStudentRepository()
+    const submissionRepository = new InMemorySubmissionRepository()
+    const assessmentRepository = new InMemoryAssessmentRepository()
+    const service = new ReportListApplicationService(
+      courseRepository,
+      reportRepository,
+      studentRepository,
+      submissionRepository,
+      assessmentRepository
+    )
+    const course = new Course(27048, 'コミュニケーション技術特論2')
+    await courseRepository.saveAsync(course)
+    const report = new Report(
+      course.id,
+      35677,
+      '個人レポート課題',
+      'folderAbsolutePath'
+    )
+    await reportRepository.saveAsync(report)
+
+    const getResult = await service.getReportCourseAsync()
+
+    expect(getResult.length).toBe(1)
+    expect(getResult[0].courseId).toBe(27048)
+    expect(getResult[0].courseName).toBe('コミュニケーション技術特論2')
+    expect(getResult[0].reportId).toBe(35677)
+    expect(getResult[0].reportTitle).toBe('個人レポート課題')
+  })
 })
 
 describe('export', () => {

--- a/src/application/reportLists/reportListApplicationService.ts
+++ b/src/application/reportLists/reportListApplicationService.ts
@@ -20,6 +20,7 @@ import { ReportListData } from './reportListData'
 import path from 'path'
 import { ReportListExportCommand } from './reportListExportCommand'
 import { ReportListExportResult } from './reportListExportResult'
+import { ReportCourseData } from './reportCourseData'
 
 /**
  * レポートリストアプリケーションサービス
@@ -113,6 +114,26 @@ export class ReportListApplicationService {
     }
 
     return reportId
+  }
+
+  /**
+   * レポートとコースのデータを取得する
+   *
+   * @returns レポートとコースのデータ
+   */
+  public async getReportCourseAsync(): Promise<ReportCourseData[]> {
+    const reports = await this.reportRepository.findAllAsync()
+    const courses = await this.courseRepository.findAllAsync()
+
+    const reportCourseDataList: ReportCourseData[] = []
+    for (const report of reports) {
+      const course = courses.find((course) => course.id === report.courseId)
+      reportCourseDataList.push(
+        new ReportCourseData(course.id, course.name, report.id, report.title)
+      )
+    }
+
+    return reportCourseDataList
   }
 
   /**

--- a/src/domain/models/courses/courseRepository.ts
+++ b/src/domain/models/courses/courseRepository.ts
@@ -17,4 +17,10 @@ export interface CourseRepository {
    * @param id ID
    */
   findAsync(id: number): Promise<Course>
+
+  /**
+   * コースを全件取得する
+   *
+   */
+  findAllAsync(): Promise<Course[]>
 }

--- a/src/domain/models/reports/reportRepository.ts
+++ b/src/domain/models/reports/reportRepository.ts
@@ -17,4 +17,10 @@ export interface ReportRepository {
    * @param id ID
    */
   findAsync(id: number): Promise<Report>
+
+  /**
+   * レポートを全件取得する
+   *
+   */
+  findAllAsync(): Promise<Report[]>
 }

--- a/src/infrastructure/inMemory/courses/inMemoryCourseRepository.test.ts
+++ b/src/infrastructure/inMemory/courses/inMemoryCourseRepository.test.ts
@@ -13,4 +13,16 @@ describe('save', () => {
     expect(actual.id).toBe(expected.id)
     expect(actual.name).toBe(expected.name)
   })
+
+  test('should return all courses', async () => {
+    const repository = new InMemoryCourseRepository()
+    const expected1 = new Course(1, 'name')
+    const expected2 = new Course(2, 'name')
+
+    await repository.saveAsync(expected1)
+    await repository.saveAsync(expected2)
+
+    const actual = await repository.findAllAsync()
+    expect(actual.length).toBe(2)
+  })
 })

--- a/src/infrastructure/inMemory/courses/inMemoryCourseRepository.ts
+++ b/src/infrastructure/inMemory/courses/inMemoryCourseRepository.ts
@@ -32,4 +32,13 @@ export class InMemoryCourseRepository implements CourseRepository {
     }
     return course
   }
+
+  /**
+   * コースを全件取得する
+   *
+   * @returns コース
+   */
+  public async findAllAsync(): Promise<Course[]> {
+    return Array.from(this.courses.values())
+  }
 }

--- a/src/infrastructure/inMemory/reports/inMemoryReportRepository.test.ts
+++ b/src/infrastructure/inMemory/reports/inMemoryReportRepository.test.ts
@@ -17,4 +17,26 @@ describe('save', () => {
       expected.reportListFolderAbsolutePath
     )
   })
+
+  test('should return all reports', async () => {
+    const repository = new InMemoryReportRepository()
+    const expected1 = new Report(
+      1,
+      1,
+      'title1',
+      'reportListFolderAbsolutePath1'
+    )
+    const expected2 = new Report(
+      2,
+      2,
+      'title2',
+      'reportListFolderAbsolutePath2'
+    )
+
+    await repository.saveAsync(expected1)
+    await repository.saveAsync(expected2)
+
+    const actual = await repository.findAllAsync()
+    expect(actual.length).toBe(2)
+  })
 })

--- a/src/infrastructure/inMemory/reports/inMemoryReportRepository.ts
+++ b/src/infrastructure/inMemory/reports/inMemoryReportRepository.ts
@@ -32,4 +32,13 @@ export class InMemoryReportRepository implements ReportRepository {
     }
     return report
   }
+
+  /**
+   * レポートを全件取得する
+   *
+   * @returns レポート
+   */
+  public async findAllAsync(): Promise<Report[]> {
+    return Array.from(this.reports.values())
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,6 +93,11 @@ app.whenReady().then(() => {
   )
 
   ipcMain.handle(
+    'getReportCourseAsync',
+    async () => await reportListApplicationService.getReportCourseAsync()
+  )
+
+  ipcMain.handle(
     'getReportListAsync',
     async (_, reportListGetCommand: ReportListGetCommand) =>
       await reportListApplicationService.getAsync(reportListGetCommand)

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -19,6 +19,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   exportReportListAsync: (reportListExportCommand: ReportListExportCommand) =>
     ipcRenderer.invoke('exportReportListAsync', reportListExportCommand),
 
+  getReportCourseAsync: () => ipcRenderer.invoke('getReportCourseAsync'),
+
   getReportListAsync: (reportListGetCommand: ReportListGetCommand) =>
     ipcRenderer.invoke('getReportListAsync', reportListGetCommand),
 


### PR DESCRIPTION
分類ページに遷移するカードを作成するため、レポートとコースのデータを取得するAPIを作成しています