### PR TITLE
分類ページでのコース名表示

### DIFF
--- a/src/presentation/pages/Classification.tsx
+++ b/src/presentation/pages/Classification.tsx
@@ -22,7 +22,6 @@ import { AssessmentGrade } from 'src/domain/models/assessments/assessmentGrade'
 import { BackButton } from '../common/button/BackButton'
 import Loading from '../common/isLoading/Loading'
 import Error from '../common/error/Error'
-import { ReportCourseData } from 'src/application/reportCourse/reportCourseData'
 
 const Classification = () => {
   const { id } = useParams()
@@ -33,9 +32,7 @@ const Classification = () => {
   const [draggingSubmissionId, setDraggingSubmissionId] = useState(null)
   const [selectedStudentIds, setSelectedStudentIds] = useState<number[]>([])
   const [report, setReport] = useState<Report | null>(null)
-  const [reportCourse, setReportCourse] = useState<ReportCourseData>(
-    new ReportCourseData(0, '', 0, '')
-  )
+  const [courseName, setCourseName] = useState<string>('')
   const [assessmentGrades, setAssessmentGrades] = useState<
     {
       id: number
@@ -167,27 +164,10 @@ const Classification = () => {
         })
         setReport({
           id: res.reportListData.reportId,
-          title: res.reportListData.courseName,
+          title: res.reportListData.reportTitle,
           items: newItems,
         })
-        setProcess('success')
-      })
-      .catch((err) => {
-        setProcess('error')
-      })
-      .finally(() => {
-        setProcess('success')
-      })
-  }, [id])
-
-  useEffect(() => {
-    window.electronAPI
-      .getReportCourseAsync()
-      .then((res) => {
-        const newReportCourse = res.reportCourseDataList.find(
-          (data: ReportCourseData) => data.reportId === Number(id)
-        )
-        setReportCourse(newReportCourse)
+        setCourseName(res.reportListData.courseName)
         setProcess('success')
       })
       .catch((err) => {
@@ -292,12 +272,12 @@ const Classification = () => {
                     {/* courseName */}
                     <h1 className="flex ml-2 text-xl">
                       <p className="mr-2">コース名</p>
-                      {reportCourse.courseName}
+                      {courseName}
                     </h1>
                     {/* courseName */}
                     <h2 className="flex ml-2 text-base">
                       <p className="mr-2">レポート名</p>
-                      {reportCourse.reportTitle}
+                      {report.title}
                     </h2>
                   </div>
                 </div>

--- a/src/presentation/pages/Classification.tsx
+++ b/src/presentation/pages/Classification.tsx
@@ -22,6 +22,7 @@ import { AssessmentGrade } from 'src/domain/models/assessments/assessmentGrade'
 import { BackButton } from '../common/button/BackButton'
 import Loading from '../common/isLoading/Loading'
 import Error from '../common/error/Error'
+import { ReportCourseData } from 'src/application/reportCourse/reportCourseData'
 
 const Classification = () => {
   const { id } = useParams()
@@ -32,6 +33,9 @@ const Classification = () => {
   const [draggingSubmissionId, setDraggingSubmissionId] = useState(null)
   const [selectedStudentIds, setSelectedStudentIds] = useState<number[]>([])
   const [report, setReport] = useState<Report | null>(null)
+  const [reportCourse, setReportCourse] = useState<ReportCourseData>(
+    new ReportCourseData(0, '', 0, '')
+  )
   const [assessmentGrades, setAssessmentGrades] = useState<
     {
       id: number
@@ -177,6 +181,24 @@ const Classification = () => {
   }, [id])
 
   useEffect(() => {
+    window.electronAPI
+      .getReportCourseAsync()
+      .then((res) => {
+        const newReportCourse = res.reportCourseDataList.find(
+          (data: ReportCourseData) => data.reportId === Number(id)
+        )
+        setReportCourse(newReportCourse)
+        setProcess('success')
+      })
+      .catch((err) => {
+        setProcess('error')
+      })
+      .finally(() => {
+        setProcess('success')
+      })
+  }, [id])
+
+  useEffect(() => {
     if (!report) return
     setAssessmentGrades(
       assessmentGrades.map((grade) => ({
@@ -266,7 +288,18 @@ const Classification = () => {
               <div className="flex justify-between">
                 <div className="flex justify-between">
                   <BackButton href={`/`} />
-                  <h1 className="ml-2 text-2xl">{report.title}</h1>
+                  <div>
+                    {/* courseName */}
+                    <h1 className="flex ml-2 text-xl">
+                      <p className="mr-2">コース名</p>
+                      {reportCourse.courseName}
+                    </h1>
+                    {/* courseName */}
+                    <h2 className="flex ml-2 text-base">
+                      <p className="mr-2">レポート名</p>
+                      {reportCourse.reportTitle}
+                    </h2>
+                  </div>
                 </div>
                 <div className="mt-2">
                   <SelectedButton


### PR DESCRIPTION
#174
変更内容
・コース名、レポート名の読み込み追加
・コース名、レポート名のスタイル調整

確認内容
・分類ページにコース名とレポート名が表示されていることを確認
・コース名とレポート名のフォントサイズ、位置が他の要素に重ならないことを確認

懸念事項
#181 のPRで実装されたuseReportCourseを使って実装したほうが良いかも