### PR TITLE
PDF表示コンテナにスクロールバーを追加する

### DIFF
--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -27,7 +27,7 @@ const Review = () => {
   if (error) return <Error />
   return (
     <>
-      <div className="h-full overflow-y-auto">
+      <div className="h-full overflow-hidden">
         {/* navbar */}
         <div className="z-50 bg-white fixed top-0 flex items-center w-full p-2 border-b shadow-sm">
           {/* 戻るボタン */}
@@ -37,7 +37,7 @@ const Review = () => {
         {/* メインコンテンツ */}
         <div className="flex mt-14" style={{ height: 'calc(100vh - 4rem)' }}>
           {/* PDF表示 */}
-          <div className="w-10/12 pl-8 pt-5 overflow-x-auto whitespace-nowrap flex">
+          <div className="w-10/12 pl-8 pt-5 overflow-x-auto whitespace-nowrap flex overflow-y-hidden">
             {submissionSummaries.map((summary, index) => (
               <StudentSubmissions
                 key={index}

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -44,7 +44,7 @@ const Review = () => {
                 reportId={Number(reportId)}
                 student={summary.student}
                 files={summary.files}
-                height="calc(100vh - 4rem)"
+                height="calc(100vh - 6rem)"
                 width={1100}
                 pageHeight={1200}
                 submission={summary.submission}

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -27,7 +27,7 @@ const Review = () => {
   if (error) return <Error />
   return (
     <>
-      <div className="h-full overflow-hidden">
+      <div className="h-full overflow-y-auto">
         {/* navbar */}
         <div className="z-50 bg-white fixed top-0 flex items-center w-full p-2 border-b shadow-sm">
           {/* 戻るボタン */}
@@ -37,7 +37,7 @@ const Review = () => {
         {/* メインコンテンツ */}
         <div className="flex mt-14" style={{ height: 'calc(100vh - 4rem)' }}>
           {/* PDF表示 */}
-          <div className="w-10/12 pl-8 pt-5 overflow-x-auto whitespace-nowrap flex overflow-y-hidden">
+          <div className="w-10/12 pl-8 pt-5 overflow-x-auto whitespace-nowrap flex">
             {submissionSummaries.map((summary, index) => (
               <StudentSubmissions
                 key={index}
@@ -45,8 +45,8 @@ const Review = () => {
                 student={summary.student}
                 files={summary.files}
                 height="calc(100vh - 4rem)"
-                width={900}
-                pageHeight={1000}
+                width={1000}
+                pageHeight={1200}
                 submission={summary.submission}
               />
             ))}

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -45,7 +45,7 @@ const Review = () => {
                 student={summary.student}
                 files={summary.files}
                 height="calc(100vh - 4rem)"
-                width={1000}
+                width={1100}
                 pageHeight={1200}
                 submission={summary.submission}
               />

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -40,7 +40,10 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
   // 未提出の場合は例外テキストを表示
   if (!submission.isSubmitted) {
     return (
-      <StudentSubmissionsHeader student={student} style={{ height, width }}>
+      <StudentSubmissionsHeader
+        student={student}
+        style={{ height, width, flexShrink: 0 }}
+      >
         <SubmissionContainer height={height}>
           <p className="border border-gray-300 p-4 rounded bg-gray-100">
             未提出の為、表示するデータがありません
@@ -75,11 +78,14 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
   }, [reportId, student.numId, files])
 
   return (
-    <StudentSubmissionsHeader student={student} style={{ height, width }}>
+    <StudentSubmissionsHeader
+      student={student}
+      style={{ height, width, flexShrink: 0 }}
+    >
       <SubmissionContainer height={height}>
         <SubmissionPdfContainer
           files={pdfFiles}
-          width={width}
+          width={width - 50}
           pageHeight={pageHeight}
         />
       </SubmissionContainer>

--- a/src/presentation/review/components/StudentSubmissionsHeader.tsx
+++ b/src/presentation/review/components/StudentSubmissionsHeader.tsx
@@ -17,7 +17,10 @@ const StudentSubmissionsHeader: React.FC<StudentSubmissionsHeaderProps> = ({
   style,
   children,
 }) => (
-  <div className="text-center p-4 border-x" style={style}>
+  <div
+    className="text-center p-4 border-x overflow-x-auto overflow-y-hidden"
+    style={style}
+  >
     <h2 className="text-2xl font-bold">{student.name}</h2>
     {children}
   </div>

--- a/src/presentation/review/components/SubmissionContainer.tsx
+++ b/src/presentation/review/components/SubmissionContainer.tsx
@@ -9,7 +9,7 @@ const SubmissionContainer: React.FC<SubmissionContainerProps> = ({
   height,
   children,
 }) => (
-  <div className="overflow-y-auto" style={{ height }}>
+  <div className="overflow-y-auto pb-4" style={{ height }}>
     {children}
   </div>
 )

--- a/src/presentation/review/components/SubmissionPdfContainer.tsx
+++ b/src/presentation/review/components/SubmissionPdfContainer.tsx
@@ -60,11 +60,7 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
   return (
     <>
       {memoizedFiles.map(({ fileName, url, index }) => (
-        <div
-          key={`pdf-${index}`}
-          className="mb-5 overflow-y-auto"
-          style={{ width, height: pageHeight }}
-        >
+        <div key={`pdf-${index}`} className="mb-5" style={{ width }}>
           <div className="font-bold mb-2 p-2 border border-gray-300 rounded bg-gray-100">
             {fileName}
           </div>
@@ -74,6 +70,8 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
                 width,
                 height: pageHeight,
                 overflowY: 'auto',
+                border: '1px solid #ccc',
+                borderRadius: '4px',
               }}
             >
               <Document
@@ -86,7 +84,6 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
                     key={`page-${index}-${pageIndex + 1}`}
                     pageNumber={pageIndex + 1}
                     width={width}
-                    height={pageHeight}
                   />
                 ))}
               </Document>

--- a/src/presentation/review/components/SubmissionPdfContainer.tsx
+++ b/src/presentation/review/components/SubmissionPdfContainer.tsx
@@ -69,20 +69,28 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
             {fileName}
           </div>
           {fileTypes[url] === 'application/pdf' ? (
-            <Document
-              file={url}
-              onLoadSuccess={(pdf) => onDocumentLoadSuccess(index, pdf)}
-              options={memoizedOptions}
+            <div
+              style={{
+                width,
+                height: pageHeight,
+                overflowY: 'auto',
+              }}
             >
-              {Array.from(new Array(numPages[index] || 0), (_, pageIndex) => (
-                <Page
-                  key={`page-${index}-${pageIndex + 1}`}
-                  pageNumber={pageIndex + 1}
-                  width={width}
-                  height={pageHeight}
-                />
-              ))}
-            </Document>
+              <Document
+                file={url}
+                onLoadSuccess={(pdf) => onDocumentLoadSuccess(index, pdf)}
+                options={memoizedOptions}
+              >
+                {Array.from(new Array(numPages[index] || 0), (_, pageIndex) => (
+                  <Page
+                    key={`page-${index}-${pageIndex + 1}`}
+                    pageNumber={pageIndex + 1}
+                    width={width}
+                    height={pageHeight}
+                  />
+                ))}
+              </Document>
+            </div>
           ) : (
             <div className="border border-gray-300 p-4 rounded bg-gray-100">
               このファイルタイプの表示はサポートされていません。

--- a/src/presentation/review/components/SubmissionPdfContainer.tsx
+++ b/src/presentation/review/components/SubmissionPdfContainer.tsx
@@ -67,7 +67,7 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
           {fileTypes[url] === 'application/pdf' ? (
             <div
               style={{
-                // width,
+                width,
                 height: pageHeight,
                 overflowY: 'auto',
                 border: '1px solid #ccc',

--- a/src/presentation/review/components/SubmissionPdfContainer.tsx
+++ b/src/presentation/review/components/SubmissionPdfContainer.tsx
@@ -67,7 +67,7 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
           {fileTypes[url] === 'application/pdf' ? (
             <div
               style={{
-                width,
+                // width,
                 height: pageHeight,
                 overflowY: 'auto',
                 border: '1px solid #ccc',


### PR DESCRIPTION
- 概要
  - PDFファイルのコンテナー (div) でもスクロールバーがでる様に変更

- 変更点
  - バーが表示される様に各階層の div の height, width を調整
  - ユーザが複数選択されると均等割りされてしまうので  ```flexShrink: 0``` を設定
  - SubmissionPdfContainer の height を削除 (空でも一定の高さを指定する様になっていた)
  - PDFファイルがわかりやすい様にふちどり (div border) を設定
  - 一番下のファイルが見切れるところを修正

- 既知の問題
  - height, width を決めうちするのではなく、自動調整したほうがいい気がする

- スクリーンショット
  - <img width="1439" alt="image" src="https://github.com/user-attachments/assets/7f584ebf-c27a-45b9-91ed-1589521d223a">
