### PR TITLE
#202  【Classification ページ】SubmissionCard を未分類エリアにドロップすると、grade と rank が null に設定される

### DIFF
--- a/src/presentation/pages/Classification.tsx
+++ b/src/presentation/pages/Classification.tsx
@@ -56,7 +56,7 @@ const Classification = () => {
     setDraggingSubmissionId(event.active.id)
   }
 
-  const handleDragEnd = (event: DragEndEvent) => {
+  const handleDragEnd = async (event: DragEndEvent) => {
     setDraggingSubmissionId(null)
 
     const { active, over } = event
@@ -77,7 +77,7 @@ const Classification = () => {
       },
     }
 
-    updateAssessment(
+    await updateAssessment(
       report.id,
       newItem.student.numId,
       newItem.assessment.grade,


### PR DESCRIPTION
修正後、以下を確認しました。

- インポート直後、エクスポートするボタンが無効であること
- すべての SubmissionCard を未分類以外に分類後、エクスポートボタンが有効になること
- SubmissionCard を未分類以外から未分類にドラッグ & ドロップでき、SubmissionCard が消えないこと
- SubmissionCard を未分類以外から未分類にドラッグ & ドロップしたとき、assessments.json に grade と rank が null のデータが含まれていないこと