### PR TITLE
reviewページでのスコア部分の修正

### DIFF
--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -67,7 +67,7 @@ const Sidebar: React.FC<IPropsSidebar> = ({
               submissionSummaries.find(
                 (summary: SubmissionSummaryData) =>
                   summary.student.numId === selectedStudent.numId
-              )?.assessment.score
+              )?.assessment.score ?? '--'
             }
             variant="outlined"
             fullWidth

--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -61,7 +61,7 @@ const Sidebar: React.FC<IPropsSidebar> = ({
         <div className="pl-3">
           <TextField
             id="score"
-            type="number"
+            type="text"
             disabled
             value={
               submissionSummaries.find(
@@ -73,8 +73,6 @@ const Sidebar: React.FC<IPropsSidebar> = ({
             fullWidth
             inputProps={{
               'aria-label': 'Without label',
-              min: 0,
-              max: 100,
             }}
           />
         </div>


### PR DESCRIPTION
メンバーミーティング中に発見した
学生を切り替えた際に、未分類の学生だと、score部分が残ってしまっていたのを改善しました