### PR TITLE
PDFの見栄えの変更

### DIFF
--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -44,8 +44,6 @@ const Review = () => {
                 reportId={Number(reportId)}
                 student={summary.student}
                 files={summary.files}
-                // height="calc(100vh - 6rem)"
-                width={1100}
                 submission={summary.submission}
               />
             ))}

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -44,7 +44,7 @@ const Review = () => {
                 reportId={Number(reportId)}
                 student={summary.student}
                 files={summary.files}
-                height="calc(100vh - 6rem)"
+                // height="calc(100vh - 6rem)"
                 width={1100}
                 submission={summary.submission}
               />

--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -46,7 +46,6 @@ const Review = () => {
                 files={summary.files}
                 height="calc(100vh - 6rem)"
                 width={1100}
-                pageHeight={1200}
                 submission={summary.submission}
               />
             ))}

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -84,7 +84,7 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
         <SubmissionPdfContainer
           files={pdfUrls}
           width={pageWidth}
-          pageHeight={pageHeight}
+          height={pageHeight}
         />
       </SubmissionContainer>
     </StudentSubmissionsHeader>

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
-import { SubmissionFileGetCommand } from 'src/application/submissionFiles/submissionFileGetCommand'
 import StudentSubmissionsHeader from './StudentSubmissionsHeader'
 import SubmissionContainer from './SubmissionContainer'
 import SubmissionPdfContainer from './SubmissionPdfContainer'

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -19,7 +19,6 @@ interface StudentSubmissionsProps {
   files: string[]
   height: string
   width: number
-  pageHeight: number
   submission: Submission
 }
 
@@ -35,9 +34,10 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
   files,
   height,
   width,
-  pageHeight,
   submission,
 }) => {
+  const pageHeight = (297 / 210) * width // A4縦の比率で高さを計算
+
   // 未提出の場合は例外テキストを表示
   if (!submission.isSubmitted) {
     return (
@@ -82,7 +82,7 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
       <SubmissionContainer height={height}>
         <SubmissionPdfContainer
           files={pdfUrls}
-          width={width - 50}
+          width={width - 50} // 50pxは Submission Container の外側の div 用の スクロールバーの幅
           pageHeight={pageHeight}
         />
       </SubmissionContainer>

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -32,9 +32,34 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
   files,
   submission,
 }) => {
+  // ウィンドウの幅と高さを計算するための状態を定義
+  const [dimensions, setDimensions] = useState({
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+  })
+
+  // ウィンドウのリサイズイベントに対応するためのエフェクトを定義
+  useEffect(() => {
+    const handleResize = () => {
+      setDimensions({
+        innerWidth: window.innerWidth,
+        innerHeight: window.innerHeight,
+      })
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    // クリーンアップ関数でイベントリスナーを削除
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
   // 学生毎の縦のdiv
-  const height = 'calc(100vh - 6rem)'
-  const width = 1100
+  const { innerWidth, innerHeight } = dimensions
+  const width = innerWidth / 2
+  const height = `calc(${innerHeight}px - 6rem)`
+
   // PDF用div
   const pageHeight = (297 / 210) * width // A4縦の比率で高さを計算
   const pageWidth = width - 50 // 50pxは Submission Container の外側の div 用の スクロールバーの幅

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -17,7 +17,7 @@ interface StudentSubmissionsProps {
   reportId: number
   student: Student
   files: string[]
-  height: string
+  // height: string
   width: number
   submission: Submission
 }
@@ -32,10 +32,11 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
   reportId,
   student,
   files,
-  height,
+  // height,
   width,
   submission,
 }) => {
+  const height = 'calc(100vh - 6rem)'
   const pageHeight = (297 / 210) * width // A4縦の比率で高さを計算
 
   // 未提出の場合は例外テキストを表示

--- a/src/presentation/review/components/StudentSubmissions.tsx
+++ b/src/presentation/review/components/StudentSubmissions.tsx
@@ -17,8 +17,6 @@ interface StudentSubmissionsProps {
   reportId: number
   student: Student
   files: string[]
-  // height: string
-  width: number
   submission: Submission
 }
 
@@ -32,12 +30,14 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
   reportId,
   student,
   files,
-  // height,
-  width,
   submission,
 }) => {
+  // 学生毎の縦のdiv
   const height = 'calc(100vh - 6rem)'
+  const width = 1100
+  // PDF用div
   const pageHeight = (297 / 210) * width // A4縦の比率で高さを計算
+  const pageWidth = width - 50 // 50pxは Submission Container の外側の div 用の スクロールバーの幅
 
   // 未提出の場合は例外テキストを表示
   if (!submission.isSubmitted) {
@@ -83,7 +83,7 @@ const StudentSubmissions: React.FC<StudentSubmissionsProps> = ({
       <SubmissionContainer height={height}>
         <SubmissionPdfContainer
           files={pdfUrls}
-          width={width - 50} // 50pxは Submission Container の外側の div 用の スクロールバーの幅
+          width={pageWidth}
           pageHeight={pageHeight}
         />
       </SubmissionContainer>

--- a/src/presentation/review/components/SubmissionContainer.tsx
+++ b/src/presentation/review/components/SubmissionContainer.tsx
@@ -9,7 +9,7 @@ const SubmissionContainer: React.FC<SubmissionContainerProps> = ({
   height,
   children,
 }) => (
-  <div className="overflow-y-auto pb-4" style={{ height }}>
+  <div className="overflow-y-auto pb-8" style={{ height }}>
     {children}
   </div>
 )

--- a/src/presentation/review/components/SubmissionContainer.tsx
+++ b/src/presentation/review/components/SubmissionContainer.tsx
@@ -9,6 +9,7 @@ const SubmissionContainer: React.FC<SubmissionContainerProps> = ({
   height,
   children,
 }) => (
+  // 複数ファイルの一番下が見切れる場合は pb を深くする / なんか自動調整できるようにしたい
   <div className="overflow-y-auto pb-8" style={{ height }}>
     {children}
   </div>

--- a/src/presentation/review/components/SubmissionPdfContainer.tsx
+++ b/src/presentation/review/components/SubmissionPdfContainer.tsx
@@ -7,13 +7,13 @@ pdfjs.GlobalWorkerOptions.workerSrc = `./pdf.worker.min.mjs`
 interface SubmissionPdfContainerProps {
   files: { name: string; url: string }[]
   width: number
-  pageHeight: number
+  height: number
 }
 
 const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
   files,
   width,
-  pageHeight,
+  height,
 }) => {
   const [numPages, setNumPages] = useState<number[]>([])
   const [fileTypes, setFileTypes] = useState<{ [key: string]: string }>({})
@@ -68,7 +68,7 @@ const SubmissionPdfContainer: React.FC<SubmissionPdfContainerProps> = ({
             <div
               style={{
                 width,
-                height: pageHeight,
+                height,
                 overflowY: 'auto',
                 border: '1px solid #ccc',
                 borderRadius: '4px',


### PR DESCRIPTION
- 概要
  - FHD 等の解像度で PDF 表示がでかすぎる問題他を修正

- スクリーンショット
  - 
![image](https://github.com/user-attachments/assets/e3e60b52-22de-4a97-a466-b7ce06007047)


- 修正内容
  - StudentSubmissions.tsx で使ってない import を削除
  - Review.tsx > StudentSubmissions.tsx の props を最小限に変更 (サイズ関連は Review から投げない)
  - StudentSubmissions 内で自動的にウィンドウサイズを取得して各種のサイズを指定
    - 学生毎の縦カラムの幅は、ウィンドウサイズの半分に
    - 結果として、PDF は 1.5 人くらいに入るようになってる筈
  - 複数ファイル表示時の一番下のPDF表示が切れる問題の対処として、SubmissionContainer div の pb を調節

- 既知の問題
  - だいたいFHDくらいだろうという比率で、ウィンドウサイズを基準に調整するので、横長なウィンドウにしたり、逆に横幅が狭いウィンドウにしたりすると表示が崩れる

- お願い
  - コードだけでなく、みんなの環境で表示してみて欲しい