### PR TITLE
ラジオボタンに、初期値が設定されないバグを修正

### DIFF
--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { SubmissionSummaryData } from 'src/application/submissionSummaries/submissionSummaryData'
 import { SubmissionSummaryStudentData } from 'src/application/submissionSummaries/submissionSummaryStudentData'
 import StudentSelectionRadioGroup from 'src/presentation/review/components/StudentSelectionRadioGroup'
@@ -21,6 +21,12 @@ const Sidebar: React.FC<IPropsSidebar> = ({
   // 選択された学生
   const [selectedStudent, setSelectedStudent] =
     useState<SubmissionSummaryStudentData>(submissionSummaries[0].student)
+
+  // 非同期処理でのsubmissionSummariesの取得のため
+  // selectedStudentの初期値が更新されないことがあるため、useEffectで初期値を設定
+  useEffect(() => {
+    setSelectedStudent(submissionSummaries[0].student)
+  }, [submissionSummaries])
 
   return (
     <div className="w-96 p-4 m-2 border-l-4 flex flex-col justify-start overflow-y-auto">

--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -22,8 +22,7 @@ const Sidebar: React.FC<IPropsSidebar> = ({
   const [selectedStudent, setSelectedStudent] =
     useState<SubmissionSummaryStudentData>(submissionSummaries[0].student)
 
-  // 非同期処理でのsubmissionSummariesの取得のため
-  // selectedStudentの初期値が更新されないことがあるため、useEffectで初期値を設定
+  // レンダリングごとに、最初の学生を選択状態にする
   useEffect(() => {
     setSelectedStudent(submissionSummaries[0].student)
   }, [submissionSummaries])


### PR DESCRIPTION
レビュー ページに遷移した際に、学生選択のラジオボタンに初期値が設定されないバグがありました。この問題を解決するために、useEffectを使用して非同期処理後にsubmissionSummariesが更新されると、selectedStudentを更新しなおす対応を行いました。