### PR TITLE
学生選択を更新するuseEffectの依存配列の値を、プリミティブ型に変更

### DIFF
--- a/src/presentation/pages/Review.tsx
+++ b/src/presentation/pages/Review.tsx
@@ -52,6 +52,7 @@ const Review = () => {
           <Sidebar
             reportId={reportId}
             submissionSummaries={submissionSummaries}
+            initialStudent={submissionSummaries[0].student}
           />
         </div>
       </div>

--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -24,7 +24,7 @@ const Sidebar: React.FC<IPropsSidebar> = ({
   const [selectedStudent, setSelectedStudent] =
     useState<SubmissionSummaryStudentData>(initialStudent)
 
-  // レンダリングごとに選択された学生を初期化
+  // レンダリングごとに、最初の学生を選択状態にする
   useEffect(() => {
     setSelectedStudent(initialStudent)
   }, [initialStudent.numId])

--- a/src/presentation/review/components/Sidebar.tsx
+++ b/src/presentation/review/components/Sidebar.tsx
@@ -11,21 +11,23 @@ import TextField from '@mui/material/TextField'
 interface IPropsSidebar {
   reportId: string
   submissionSummaries: SubmissionSummaryData[]
+  initialStudent: SubmissionSummaryStudentData
 }
 
 // reviewページサイドバーコンポーネント
 const Sidebar: React.FC<IPropsSidebar> = ({
   reportId,
   submissionSummaries,
+  initialStudent,
 }) => {
   // 選択された学生
   const [selectedStudent, setSelectedStudent] =
-    useState<SubmissionSummaryStudentData>(submissionSummaries[0].student)
+    useState<SubmissionSummaryStudentData>(initialStudent)
 
-  // レンダリングごとに、最初の学生を選択状態にする
+  // レンダリングごとに選択された学生を初期化
   useEffect(() => {
-    setSelectedStudent(submissionSummaries[0].student)
-  }, [submissionSummaries])
+    setSelectedStudent(initialStudent)
+  }, [initialStudent.numId])
 
   return (
     <div className="w-96 p-4 m-2 border-l-4 flex flex-col justify-start overflow-y-auto">


### PR DESCRIPTION
分類、メモ、フィードバックを更新するたびに、mutate が実行されていたため、ラジオボタンの学生選択にも更新が走っていました。これは、useEffect の依存配列にオブジェクト型である submissionSummaries を渡していたためです。新しいオブジェクトとして設定されるたびに、useEffect が再実行され、選択された学生が更新されていました。

この問題を解決するために、依存配列にプリミティブ型を渡しました。プリミティブ型は値自体で比較されるため、値が同じであれば再実行されません。これにより、不要な再実行が防止され、ラジオボタンの選択が適切に保持されるようにしました。