### PR TITLE
 #213 package.json の author を修正する 

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
   },
   "keywords": [],
   "author": {
-    "name": "a2311kk",
-    "email": "166212224+a2311kk@users.noreply.github.com"
+    "name": "ChubachiPT2024"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
本来は author には 1 人の人を書くようですが、今回はパッケージを公開する訳でもないので、とりあえず ChubachiPT2024 にしました。

> The "author" is one person.

https://docs.npmjs.com/cli/v10/configuring-npm/package-json#people-fields-author-contributors